### PR TITLE
FIX: prop() type detection & support for schema plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ user.save()
 
 `@model(name: string, options?: SchemaOptions)`
 
-`@index(fields: IIndexArgs['fields'], options?: IIndexArgs['options']`
+`@index(fields: IIndexArgs['fields'], options?: IIndexArgs['options'])`
+
+`@plugin<T>(plugin: IPluginType<T>, options?: T)` registers a mongoose [schema plugin](https://mongoosejs.com/docs/plugins.html)
 
 `@subModel(options: SchemaOptions & {name?: string} = {})`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-typescript",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,5 +78,9 @@ function buildSchema(meta: MongooseMeta): Schema {
     (schema[hookType] as any)(actionType, fn)
   })
 
+  meta.plugins.forEach(({plugin, options}) => {
+    schema.plugin(plugin, options)
+  })
+
   return schema
 }

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -1,4 +1,4 @@
-import {SchemaOptions} from 'mongoose'
+import {SchemaOptions, Schema} from 'mongoose'
 import {ActionType, HookType} from './middleware'
 
 export type Fn = (...args: any[]) => any
@@ -11,6 +11,13 @@ export interface IIndexArgs {
   }
 }
 
+export type IPluginType<T> = (schema: Schema, options?: T) => void
+
+export interface IPluginArgs<T> {
+  plugin: IPluginType<T>;
+  options?: T;
+}
+
 export class MongooseMeta {
 
   public name: string
@@ -21,6 +28,7 @@ export class MongooseMeta {
   public queries: {[name: string]: Fn} = {}
   public indexes: IIndexArgs[] = []
   public middleware: Array<[ActionType, HookType, Fn]> = []
+  public plugins: Array<IPluginArgs<any>> = []
 
   public options: SchemaOptions = null
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,5 @@
 import {SchemaOptions} from 'mongoose'
-import {getMongooseMeta, IIndexArgs, IMongooseClass} from './meta'
+import {getMongooseMeta, IIndexArgs, IMongooseClass, IPluginArgs} from './meta'
 
 export function model(name: string, options?: SchemaOptions) {
   return (target: IMongooseClass) => {
@@ -26,5 +26,12 @@ export function subModel(options: SchemaOptions & {name?: string} = {}) {
     }
     meta.name = options.name
     meta.options = options
+  }
+}
+
+export function plugin<T>(plugin: IPluginArgs<T>['plugin'], options?: IPluginArgs<T>['options']) {
+  return (target: any) => {
+    getMongooseMeta(target.prototype).plugins
+      .push({plugin, options})
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -13,7 +13,7 @@ export function prop<T>(options: SchemaTypeOpts<T> & {type?: T} = {}, type?: T):
         type = getSchema(type as any) as any
       }
     }
-    getMongooseMeta(target).schema[name] = {...pathSchema, ...options, type}
+    getMongooseMeta(target).schema[name] = {...pathSchema, ...options, ...(type ? { type } : {})}
   }
 }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,10 +4,14 @@ import 'should'
 import {
   array, getModel, getSchema, hidden, id, index, indexed, methods, middleware, Model, model, prop, Ref, ref, required,
   statics,
-  subModel, unique,
+  subModel, unique, plugin,
 } from '../src'
 
 mongoose.connect('mongodb://localhost/test')
+
+function testPlugin (schema: mongoose.Schema, options: any) {
+  schema.statics.testPluginFunc = () => options
+}
 
 @subModel()
 class Address {
@@ -31,6 +35,7 @@ let hookRun = 0
 
 @model('user')
 @middleware<User>('findOne', 'pre', () => hookRun ++)
+@plugin(testPlugin, { testPlugin: true })
 class User extends Model<User> {
   @statics
   public static async findByName(name: string): Promise<User> {
@@ -115,6 +120,10 @@ describe('User', function (this) {
 
   it('hook', function (this) {
     hookRun.should.greaterThan(0)
+  })
+
+  it('plugin', function (this) {
+    (UserModel as any).testPluginFunc().testPlugin.should.eql(true)
   })
 })
 


### PR DESCRIPTION
FIX: prop() did not consider options.type if type and pathSchema.type were both undefined

(type || pathSchema.type) = undefined shadowed any existing options.type resulting in missing path type even if options.type was defined